### PR TITLE
Dev 729 rectangle detection color

### DIFF
--- a/src/draw-zone/index.tsx
+++ b/src/draw-zone/index.tsx
@@ -1184,13 +1184,13 @@ function useDraw(
             }
 
             if (!overlayRect || !overlayRect2) {
-                overlayRect = svg.rect(0, 0).fill({ opacity: 0.5 }).stroke({
+                overlayRect = svg.rect(0, 0).fill({ opacity: 0 }).stroke({
                     color: '#000',
                     width: 2,
                     opacity: 0.7,
                     dasharray: '5,5',
                 })
-                overlayRect2 = svg.rect(0, 0).fill({ opacity: 0.5 }).stroke({
+                overlayRect2 = svg.rect(0, 0).fill({ opacity: 0 }).stroke({
                     color: '#fff',
                     width: 2,
                     opacity: 0.7,

--- a/src/draw-zone/index.tsx
+++ b/src/draw-zone/index.tsx
@@ -290,7 +290,8 @@ export function DrawZoneContainer({
 const xns = 'http://www.w3.org/1999/xlink'
 const blue = '#2BB1FD'
 const defaultStroke = { color: '#fff', width: 2, opacity: 1 }
-const defaultFill = { color: '#000', opacity: 0 }
+const defaultFill = { color: '#000', opacity: 0.5 }
+const transparentFill = {color: '#000', opacity: 0}
 
 function getRectCoords(rect: Rect) {
     const bbox = rect.bbox()
@@ -514,7 +515,7 @@ function useDraw(
         points,
         disabled = isDisabled,
         stroke = { ...defaultStroke },
-        fill = { ...defaultFill },
+        fill = { ...transparentFill },
         label,
         id = null,
     }: {
@@ -776,7 +777,7 @@ function useDraw(
         points,
         disabled = isDisabled,
         stroke = { ...defaultStroke },
-        fill = { ...defaultFill },
+        fill = { ...transparentFill },
         label,
         id = null,
     }: {
@@ -1197,8 +1198,6 @@ function useDraw(
                     dashoffset: 5,
                 })
             }
-
-            console.log(overlayRect, overlayRect2)
 
             overlayRect.move(
                 startPosition.x / svgRect.width,

--- a/src/draw-zone/index.tsx
+++ b/src/draw-zone/index.tsx
@@ -290,7 +290,7 @@ export function DrawZoneContainer({
 const xns = 'http://www.w3.org/1999/xlink'
 const blue = '#2BB1FD'
 const defaultStroke = { color: '#fff', width: 2, opacity: 1 }
-const defaultFill = { color: '#000', opacity: 0.5 }
+const defaultFill = { color: '#000', opacity: 0 }
 
 function getRectCoords(rect: Rect) {
     const bbox = rect.bbox()
@@ -766,6 +766,7 @@ function useDraw(
         rect.data('label', label)
 
         if (stroke.color !== defaultStroke.color)
+        
             rect.data('color', stroke.color)
 
         return rect
@@ -1196,6 +1197,8 @@ function useDraw(
                     dashoffset: 5,
                 })
             }
+
+            console.log(overlayRect, overlayRect2)
 
             overlayRect.move(
                 startPosition.x / svgRect.width,

--- a/src/draw-zone/index.tsx
+++ b/src/draw-zone/index.tsx
@@ -1287,7 +1287,7 @@ function useDraw(
                         .polygon(plotline)
                         .fill({
                             color: '#f06',
-                            opacity: 0.5,
+                            opacity: 0,
                         })
                         .stroke({
                             color: '#f06',


### PR DESCRIPTION
- Opacité changée lors du tracé du polygone ou du rectange sur la DrawZone et lorsque les formes se fixent pour éviter que le filtre noir ne cachent les défauts.